### PR TITLE
Fix capitilization of the actual image file

### DIFF
--- a/CHAPS/i2c/whatisit.tex
+++ b/CHAPS/i2c/whatisit.tex
@@ -2,7 +2,7 @@
    {I2C}
    \begin{figure}[H]
       \centering
-      \includegraphics[height=1in]{IMAGES/i2c-logo}
+      \includegraphics[height=1in]{IMAGES/I2C-logo}
    \end{figure}
    \begin{itemize}
       \item \textbf{I2C} (Inter-Integrated Circuit), pronounced I-squared-C


### PR DESCRIPTION
On systems where case matters (I.E. *nix platforms) i2c-logo won't
find what it's looking for and actually build.  Changing 'i2c-logo'
to 'I2C-logo' resolves this build error.